### PR TITLE
Fix bugs, disable PP, introduce activation offload

### DIFF
--- a/flame/config_manager.py
+++ b/flame/config_manager.py
@@ -682,6 +682,15 @@ class JobConfig:
             """,
         )
 
+        self.parser.add_argument(
+            "--activation_offload.mode",
+            type=str,
+            default="none",
+            help="""
+                if we are using activation offload or not. Options are ['none', 'full'].
+            """,
+        )
+
         # float8 configs
         self.parser.add_argument(
             "--float8.enable_fsdp_float8_all_gather",

--- a/flame/models/activation_offloading.py
+++ b/flame/models/activation_offloading.py
@@ -11,9 +11,9 @@ from warnings import warn
 
 import psutil
 import torch
-
 from torch import nn
 from torch.autograd.graph import saved_tensors_hooks
+
 from torchtitan.tools.logging import logger
 
 try:

--- a/flame/models/activation_offloading.py
+++ b/flame/models/activation_offloading.py
@@ -1,0 +1,443 @@
+# Adapted from https://github.com/pytorch/torchtune/blob/main/torchtune/training/_activation_offloading.py
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import contextlib
+from typing import Union
+from warnings import warn
+
+import psutil
+import torch
+
+from torch import nn
+from torch.autograd.graph import saved_tensors_hooks
+from torchtitan.tools.logging import logger
+
+try:
+    import torchao
+    from torchao.dtypes.nf4tensor import NF4Tensor
+except ImportError:
+    torchao = None
+    NF4Tensor = None
+    logger.warning("torchao not found. ")
+
+# from torchtune.modules import TiedLinear
+
+
+class OffloadActivations(saved_tensors_hooks):
+    """Context manager under which activation tensors created in the forward pass will be offloaded.
+
+    Enable the memory efficiency technique of activation offloading, where activations bigger than
+    min_offload_size bytes will be offloaded to CPU in the forward and brought back in the backward.
+    This is in contrast to maintaining the activation on GPU VRAM throughout the program.
+
+    This manager contains the option of using one additional CUDA stream to handle the communication
+    between CUDA and CPU, which is intended to overlap with the default computation stream to improve
+    runtime. We designed synchronization with a few heuristics for optimizing the tradeoff between
+    runtime vs memory usage.
+
+    Args:
+        use_pin_memory (bool): Whether or not the offloaded Tensor will be placed in pinned
+            memory on the CPU. Pinned memory allows the Tensor to be moved back onto GPU more quickly
+            but is a limited resource. Default: True.
+
+        use_streams (bool): Whether or not to use streams for performance optimization where
+            the communications get overlapped with the computation. Requires a torch build
+            after torch-2.5.0.]. Default: True.
+
+        max_fwd_stash_size (int): The maximum size of the forward stash, or the maximum number of
+            consecutive activations to keep alive during the forward pass. This number must be at
+            least 1. Keeping alive more activations will potentially allow more overlap between the
+            communication and compute streams at the cost of increasing memory usage. Keeping alive
+            fewer activations will conserve memory, but may cause poor overlap between the streams,
+            increasing runtime. Default: 5.
+
+        min_offload_size (int): The minimum number of bytes a Tensor must be in order to qualify
+            for offloading. If the tensor is too small, we do not want to waste bandwidth and resources
+            moving it to CPU and back. Default: 1024 bytes.
+
+    Raises:
+        ValueError: if max_fwd_stash_size is not at least 1.
+
+    Example:
+        >>> with OffloadActivations():
+        >>>     logits = model(inputs)
+        >>> loss = ...
+        >>> loss.backward()
+    """
+
+    def __init__(
+        self,
+        use_pin_memory: bool = True,
+        use_streams: bool = True,
+        max_fwd_stash_size: int = 5,
+        min_offload_size: int = 1024,
+    ) -> None:
+
+        self.use_streams: bool = use_streams
+
+        self.min_tensor_size_bytes = (
+            min_offload_size  # we don't want to bother with small tensors
+        )
+        self.tracker = (
+            {}
+        )  # tensor_id => (new_tensor, if_modified)  ---> track what saved/offloaded tensors are where
+        self.tensor_id: int = 0
+        self.is_first_forward_call = True
+        self.is_first_backward_call = True
+        self.is_first_forward_pass = True
+
+        # managing cpu memory
+        self.use_pin_memory: bool = use_pin_memory
+        self.virtual_memory_safe_pct = (
+            60  # we should not exceed this percentage of memory
+        )
+
+        self.s0 = torch.cuda.default_stream()  # comp stream
+
+        # for streaming
+        if self.use_streams:
+            self.s1 = torch.cuda.Stream()  # comms stream
+            self.fwd_stash = {}  # tensor_id => (activation, ev1)
+            if max_fwd_stash_size < 1:
+                raise ValueError(
+                    f"max_fwd_stash_size should be at least 1 but is {max_fwd_stash_size}"
+                )
+            self.max_fwd_stash_size = max_fwd_stash_size
+            self.bwd_tensor_stash = {}  # tensor_id => activation
+            self.bwd_ev_stash = {}  # tensor_id => ev0
+            self.curr_graph_id = None
+            self.curr_autograd_node = None
+
+        # -------- platform util functions -------- #
+        def verify_sufficient_virtual_memory():
+            curr_pct = get_cpu_ram_pct()
+            if curr_pct > self.virtual_memory_safe_pct:
+                warn(
+                    f"***** WARNING: {curr_pct=}% > {self.virtual_memory_safe_pct=}% of virtual memory used"
+                )
+
+        def get_cpu_ram_pct() -> float:
+            # get the percentage of memory used by the system
+            return psutil.virtual_memory().percent
+
+        def get_tensor_id() -> int:
+            # create a unique id for each tensor we are managing
+            self.tensor_id += 1
+            return self.tensor_id
+
+        def get_num_bytes_tensor(x: torch.Tensor) -> int:
+            # get the number of bytes in a tensor, for memory management purposes
+            return (
+                x.element_size() * x.nelement()
+            )  # x.element_size() * x._base_storage().nbytes()
+
+        # -------- core pack / unpack work -------- #
+        def pack_tensor(activation: torch.Tensor) -> int:
+            # activations are passed in during forward pass - from here we take over and return a unique id
+            if self.is_first_forward_call:
+                assert (
+                    len(self.tracker) == 0
+                ), "backward pass should have cleared tracker of all tensors"
+
+                # set training phase trackers
+                self.is_first_forward_call = False
+                self.is_first_backward_call = True
+
+            # query for basic tensor info
+            num_bytes = get_num_bytes_tensor(activation)
+            tensor_id = get_tensor_id()
+
+            # only offload hefty bois if they're activations (our heuristic for that is to
+            # check if they're not params or buffers)!
+            if num_bytes >= self.min_tensor_size_bytes and (
+                not isinstance(activation, torch.nn.Parameter)
+                and not isinstance(activation, torch.nn.Buffer)
+            ):
+                if self.use_streams:
+                    # First, sync back and dereference previously offloaded tensors
+                    # as the offloading should be done sufficiently long ago.
+                    for id in [k for k in self.fwd_stash.keys()]:
+                        if id <= tensor_id - self.max_fwd_stash_size:
+                            _, ev = self.fwd_stash[id]
+                            self.s0.wait_event(ev)
+                            del self.fwd_stash[id]
+                        else:
+                            break
+
+                    # Sync in, offload, and add an event to sync back later
+                    self.s1.wait_stream(self.s0)
+
+                stream = self.s1 if self.use_streams else self.s0
+                with torch.cuda.stream(stream):
+                    try:
+                        cpu_tensor = torch.empty_like(
+                            activation, pin_memory=self.use_pin_memory, device="cpu"
+                        )
+                    except NotImplementedError as e:
+                        if (
+                            isinstance(activation, NF4Tensor)
+                            and torchao.__version__ < "0.6.0.dev20240917"
+                        ):
+                            raise RuntimeError(
+                                "Offloading NF4Tensors requires torchao-0.6.0.dev20240917 or later"
+                            ) from e
+                        raise e
+                    cpu_tensor.copy_(activation, non_blocking=True)
+                    self.tracker[tensor_id] = (
+                        cpu_tensor,
+                        True,
+                    )  # True = (in future) modified
+
+                if self.use_streams:
+                    event = self.s1.record_event()
+
+                    # Stash to keep activation alive til s1 is done
+                    self.fwd_stash[tensor_id] = (activation, event)
+            else:
+                self.tracker[tensor_id] = (
+                    activation,
+                    False,
+                )  # False = not modified, tensor is as is
+
+            return tensor_id
+
+        def unpack_tensor_single_stream(unpack_tensor_id: int) -> torch.Tensor:
+            # backward pass - we are called with the tensor_id, which
+            # we will use to retrieve the saved/offloaded tensor
+            if self.is_first_backward_call:
+                if self.is_first_forward_pass:
+                    self.is_first_forward_pass = False
+                    if self.use_pin_memory:
+                        verify_sufficient_virtual_memory()
+
+                self.is_first_backward_call = False
+                self.is_first_forward_call = True
+
+            assert (
+                unpack_tensor_id in self.tracker
+            ), f"untracked tensor with id {unpack_tensor_id}"
+
+            maybe_gpu_tensor, modified = self.tracker[unpack_tensor_id]
+            if modified:
+                gpu_tensor = maybe_gpu_tensor.to("cuda", non_blocking=True)
+                maybe_gpu_tensor = gpu_tensor
+
+            # clear tensor from tracking
+            del self.tracker[unpack_tensor_id]
+            return maybe_gpu_tensor
+
+        def unpack_tensor_with_streams(unpack_tensor_id: int) -> torch.Tensor:
+            # backward pass - we are called with the tensor_id, which
+            # we will use to retrieve the saved/offloaded tensor
+            if self.is_first_backward_call:
+                self.curr_graph_id = torch._C._current_graph_task_id()
+
+                def wait_and_del_remaining_references() -> None:
+                    for id in [k for k in self.bwd_tensor_stash.keys()]:
+                        event = self.bwd_ev_stash[id]
+                        self.s1.wait_event(event)
+                        del self.bwd_tensor_stash[id]
+
+                # Register a callback to the end of autograd to clean everything up
+                torch.autograd.variable.Variable._execution_engine.queue_callback(
+                    wait_and_del_remaining_references
+                )
+
+                if self.is_first_forward_pass:
+                    self.is_first_forward_pass = False
+                    if self.use_pin_memory:
+                        verify_sufficient_virtual_memory()
+
+                self.is_first_backward_call = False
+                self.is_first_forward_call = True
+
+            assert (
+                unpack_tensor_id in self.tracker
+            ), f"untracked tensor with id {unpack_tensor_id}"
+
+            maybe_gpu_tensor, modified = self.tracker[unpack_tensor_id]
+            if modified:
+                # Get data on the current autograd node
+                graph_id = torch._C._current_graph_task_id()
+                node = torch._C._current_autograd_node()
+                prev_node_ids = []
+
+                # If we're on a new node, mark prev node's tensors to be freed later
+                if graph_id == self.curr_graph_id and self.curr_autograd_node != node:
+                    self.curr_autograd_node = node
+                    prev_node_ids = [id for id in self.bwd_tensor_stash.keys()]
+
+                brought_back_from_cpu = True
+                if unpack_tensor_id in self.fwd_stash:
+                    maybe_gpu_tensor = self.fwd_stash[unpack_tensor_id][0]
+                    brought_back_from_cpu = False
+                else:
+                    # Kick off the process to bring tensors back
+                    with torch.cuda.stream(self.s1):
+                        gpu_tensor = maybe_gpu_tensor.to("cuda", non_blocking=True)
+                        maybe_gpu_tensor = gpu_tensor
+
+                    # Tell comp stream to wait for the info to be loaded before executing
+                    self.s0.wait_stream(self.s1)
+
+                    # Stash the tensor to keep memory alive until compute stream is complete
+                    self.bwd_tensor_stash[unpack_tensor_id] = maybe_gpu_tensor
+
+                    # Note: [Track views of the unpacked]
+                    # Why do we get the use count of the unpacked tensor here? We want an
+                    # initial count to compare to later, during the post-hook of the
+                    # backward node, when we need to decide whether we're allowed to free
+                    # the tensor yet. In what obscure cases must we delay freeing the
+                    # tensor (and thus call record_stream)?
+                    # 1. Any of the outputs of the backward node is a view of the unpacked
+                    #    tensor.
+                    # 2. In the case that this unpacked tensor will be used in a
+                    #    checkpointed region, if one of the recomputed saved tensors ends
+                    #    up as a view of the unpacked tensor.
+                    # 3. The user abuses the system somehow and manually relies on the
+                    #    unpacked tensor to exist after the backward node has executed.
+                    storage_refcount = torch._C._storage_Use_Count(
+                        maybe_gpu_tensor.untyped_storage()._cdata
+                    )
+
+                def hook(outputs, inputs):
+                    # create events for the current node inputs/outputs if they were streamed in
+                    if brought_back_from_cpu:
+                        # See Note: [Track views of the unpacked]
+                        # IF any of the outputs is a view of the tensor, OR if a view of
+                        # the tensor has been saved as a part of checkpoint's recompute
+                        # process, OR the user has abusedly incurred a reference on the
+                        # unpacked tensor, THEN the tensor might be used later and we
+                        # cannot presume to delete it after only the current node is
+                        # done! So we use our frenemy, record_stream, to ensure the
+                        # Tensor stays unmessed with until it's done getting used in the
+                        # compute stream (s0 here). Note that the con here is we introduce
+                        # non-deterministic (thus higher) memory usage, but this case
+                        # should not happen often.
+                        unpacked_tensor = self.bwd_tensor_stash[unpack_tensor_id]
+                        if (
+                            torch._C._storage_Use_Count(
+                                unpacked_tensor.untyped_storage()._cdata
+                            )
+                            > storage_refcount
+                        ):
+                            unpacked_tensor.record_stream(self.s0)
+                            del self.bwd_tensor_stash[unpack_tensor_id]
+                        else:
+                            event = self.s0.record_event()
+                            self.bwd_ev_stash[unpack_tensor_id] = event
+
+                    # if there are still things in the fwd_stash, get rid of them as we're in bwd now
+                    for id in [k for k in self.fwd_stash.keys()]:
+                        _, ev = self.fwd_stash[id]
+                        self.s0.wait_event(ev)
+                        del self.fwd_stash[id]
+
+                    # wait on prev node's events and del those
+                    for id in prev_node_ids:
+                        event = self.bwd_ev_stash[id]
+                        self.s1.wait_event(event)
+                        del self.bwd_tensor_stash[id]
+
+                    return outputs
+
+                node.register_hook(hook)
+
+            # clear tensor from tracking
+            del self.tracker[unpack_tensor_id]
+            return maybe_gpu_tensor
+
+        unpack_tensor = (
+            unpack_tensor_with_streams
+            if self.use_streams
+            else unpack_tensor_single_stream
+        )
+        super().__init__(pack_tensor, unpack_tensor)
+
+
+class NoOpManager(saved_tensors_hooks):
+    """
+    A saved_tensors_hook manager used to disable any other saved_tensors_hook manager
+    applied before. This relies on the behavior that only the most recently registered
+    saved_tensors_hook will run.
+
+    One example usage is to opt a local region of code out of activations offloading,
+    which is usually applied globally to best track state.
+    """
+
+    def __init__(self) -> None:
+        def noop(tensor):
+            return tensor
+
+        super().__init__(noop, noop)
+
+
+def get_act_offloading_ctx_manager(
+    model: nn.Module, enable_activation_offloading: bool
+) -> Union[OffloadActivations, contextlib.nullcontext]:
+    """Returns the activation offloading context manager for the model, which will be
+    a null context if enable_activation_offloading is False.
+
+    If activation offloading is enabled, we return the OffloadActivations context manager.
+    If activation offloading is disabled, we return a NoOpManager context manager.
+
+    Args:
+        model (nn.Module): the model to wrap with the activation offloading context manager.
+        enable_activation_offloading (bool): whether or not to enable activation offloading
+            for the model.
+
+    Returns:
+        contextlib.ContextDecorator: the activation offloading context manager for the model.
+
+    Raises:
+        NotImplementedError: If the model is a multimodal model and activation offloading is enabled.
+    """
+    if enable_activation_offloading:
+        activations_handling_ctx = OffloadActivations()
+
+        # Below is our hack to disable offloading the last output Linear in every
+        # step, as the cost for offloading the activation and then soon after bringing
+        # it back is expensive. Moreover, due to heuristics in our streaming API,
+        # we actually use more memory if we offload it as it interferes with chunkedCE.
+        output_head_detected = False
+        noop_ctx = NoOpManager()
+
+        if hasattr(model, "output"):
+            if isinstance(model.output, nn.Module):
+                model.output.register_forward_pre_hook(
+                    lambda *args: noop_ctx.__enter__()
+                )
+                model.output.register_forward_hook(
+                    lambda *args: noop_ctx.__exit__(), always_call=True
+                )
+                print("registering hooks for model.output ============  ")
+                output_head_detected = True
+            # ================================
+            # ! TODO[flame] check if we need to detal with TiedLinear
+            # The following code appears in `torchtune`
+            # elif isinstance(model.output, TiedLinear):
+            #     model.output.linear.register_forward_pre_hook(
+            #         lambda *args: noop_ctx.__enter__()
+            #     )
+            #     model.output.linear.register_forward_hook(
+            #         lambda *args: noop_ctx.__exit__(), always_call=True
+            #     )
+            #     output_head_detected = True
+
+        if not output_head_detected:
+            logger.warning(
+                "During activation offloading, no output head was detected. "
+                "If your model has an output head, it will be offloaded. "
+                "This usually greatly slows training, given the large vocabulary size. "
+                "To change this behavior, set your output head as model.output and make it "
+                "an nn.Module."
+            )
+
+    else:
+        activations_handling_ctx = contextlib.nullcontext()
+
+    return activations_handling_ctx

--- a/flame/models/parallelize_fla.py
+++ b/flame/models/parallelize_fla.py
@@ -12,28 +12,23 @@ from collections import defaultdict
 import torch
 import torch.nn as nn
 from torch.distributed import DeviceMesh
-from torch.distributed._composable.fsdp import (
-    CPUOffloadPolicy,
-    MixedPrecisionPolicy,
-    fully_shard,
-)
+from torch.distributed._composable.fsdp import (CPUOffloadPolicy,
+                                                MixedPrecisionPolicy,
+                                                fully_shard)
 from torch.distributed._composable.replicate import replicate
 from torch.distributed._tensor import Replicate, Shard
-from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
-    checkpoint_wrapper as ptd_checkpoint_wrapper,
-)
-from torch.distributed.tensor.parallel import (
-    ColwiseParallel,
-    PrepareModuleInput,
-    PrepareModuleOutput,
-    RowwiseParallel,
-    SequenceParallel,
-    parallelize_module,
-)
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import \
+    checkpoint_wrapper as ptd_checkpoint_wrapper
+from torch.distributed.tensor.parallel import (ColwiseParallel,
+                                               PrepareModuleInput,
+                                               PrepareModuleOutput,
+                                               RowwiseParallel,
+                                               SequenceParallel,
+                                               parallelize_module)
 
-# from fla.modules.fused_linear_cross_entropy import LinearLossParallel
-# from fla.modules.mlp import SwiGLULinearParallel
-# from fla.modules.parallel import PrepareModuleWeight
+from fla.modules.fused_linear_cross_entropy import LinearLossParallel
+from fla.modules.mlp import SwiGLULinearParallel
+from fla.modules.parallel import PrepareModuleWeight
 from torchtitan.config_manager import TORCH_DTYPE_MAP, JobConfig
 from torchtitan.distributed.parallel_dims import ParallelDims
 from torchtitan.tools.logging import logger
@@ -131,10 +126,8 @@ class TPPlan:
         # TODO(vkuzo): add the items below to __init__.py of torchao.float8 and import from there
         try:
             from torchao.float8.float8_tensor_parallel import (
-                Float8ColwiseParallel,
-                Float8RowwiseParallel,
-                PrepareFloat8ModuleInput,
-            )
+                Float8ColwiseParallel, Float8RowwiseParallel,
+                PrepareFloat8ModuleInput)
         except ImportError:
             Float8ColwiseParallel = None
             Float8RowwiseParallel = None
@@ -275,7 +268,8 @@ def apply_tp(
             )
 
     if enable_async_tp:
-        from torch.distributed._symmetric_memory import enable_symm_mem_for_group
+        from torch.distributed._symmetric_memory import \
+            enable_symm_mem_for_group
 
         torch._inductor.config._micro_pipeline_tp = True
         enable_symm_mem_for_group(tp_mesh.get_group().group_name)
@@ -319,9 +313,7 @@ def _apply_ac_to_block(module: nn.Module, ac_config):
         )
     if use_op_sac:
         from torch.utils.checkpoint import (
-            CheckpointPolicy,
-            create_selective_checkpoint_contexts,
-        )
+            CheckpointPolicy, create_selective_checkpoint_contexts)
 
         def _get_custom_policy(meta):
             def _custom_policy(ctx, func, *args, **kwargs):

--- a/flame/models/pipeline_fla.py
+++ b/flame/models/pipeline_fla.py
@@ -13,17 +13,27 @@ import torch
 import torch.nn as nn
 from torch.distributed import DeviceMesh
 from torch.distributed.pipelining import PipelineStage
-from torch.distributed.pipelining.schedules import (ScheduleZBVZeroBubble,
-                                                    _PipelineSchedule,
-                                                    get_schedule_class)
+from torch.distributed.pipelining.schedules import (
+    ScheduleZBVZeroBubble,
+    _PipelineSchedule,
+    get_schedule_class,
+)
 from transformers import PretrainedConfig
 
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed.parallel_dims import ParallelDims
-from torchtitan.distributed.pipeline import (build_pipeline_schedule,
-                                             generate_split_points,
-                                             stage_ids_this_rank)
+from torchtitan.distributed.pipeline import (
+    build_pipeline_schedule,
+    generate_split_points,
+    stage_ids_this_rank,
+)
 from torchtitan.tools.logging import logger
+
+from flame.models.parallelize_fla import (
+    get_blocks,
+    get_real_components_name,
+    get_actual_model,
+)
 
 DeviceType = Union[int, str, torch.device]
 
@@ -90,21 +100,41 @@ def pipeline_fla_manual_split(
     ) -> tuple[PipelineStage, nn.Module]:
         model = copy.deepcopy(whole_model)
         if not is_first:
-            model.tok_embeddings = None
+            # we do `model.tok_embeddings = None` here
+            real_model = get_actual_model(model)
+            tok_embeddings_name = get_real_components_name(real_model, "tok_embeddings")
+            setattr(real_model, tok_embeddings_name, None)
 
         drop_layers = start_layer is not None
-        for name in list(model.layers.keys()):
-            # we keep layers in a contiguous region between start (inclusive) and stop (exclusive)
-            if f"layers.{name}" == start_layer:
+        # Get module dictionary from get_blocks(model)
+        # and Create a list of keys before modifying dictionary
+        module_dict = get_blocks(model)._modules  # Store reference
+        layer_names = list(module_dict.keys())
+
+        # Iterate over the list of keys instead of `_modules.items()`
+        for name in layer_names:
+            # Dynamically determine prefix (blocks.* or layers.*)
+            prefix = start_layer.split(".")[0] if start_layer else "layers"
+            layer_name = f"{prefix}.{name}"  # Construct the correct name format
+
+            # Ensure `drop_layers` activation is based on actual naming
+            if layer_name == start_layer:
                 drop_layers = False
-            if f"layers.{name}" == stop_layer:
+            if layer_name == stop_layer:
                 drop_layers = True
+
+            # Delete layer if drop_layers is active
             if drop_layers:
-                del model.layers[name]
+                del module_dict[name]  # Safe deletion from stored dictionary
 
         if not is_last:
-            model.norm = None
-            model.output = None
+            # we do `model.norm = None` and `model.output = None`
+            real_model = get_actual_model(model)
+            norm_name = get_real_components_name(real_model, "norm")
+            setattr(real_model, norm_name, None)
+
+            head_name = get_real_components_name(model, "lm_head")
+            setattr(model, head_name, None)
 
         stage = PipelineStage(
             model,

--- a/flame/models/pipeline_fla.py
+++ b/flame/models/pipeline_fla.py
@@ -13,27 +13,19 @@ import torch
 import torch.nn as nn
 from torch.distributed import DeviceMesh
 from torch.distributed.pipelining import PipelineStage
-from torch.distributed.pipelining.schedules import (
-    ScheduleZBVZeroBubble,
-    _PipelineSchedule,
-    get_schedule_class,
-)
+from torch.distributed.pipelining.schedules import (ScheduleZBVZeroBubble,
+                                                    _PipelineSchedule,
+                                                    get_schedule_class)
 from transformers import PretrainedConfig
 
+from flame.models.parallelize_fla import (get_actual_model, get_blocks,
+                                          get_real_components_name)
 from torchtitan.config_manager import JobConfig
 from torchtitan.distributed.parallel_dims import ParallelDims
-from torchtitan.distributed.pipeline import (
-    build_pipeline_schedule,
-    generate_split_points,
-    stage_ids_this_rank,
-)
+from torchtitan.distributed.pipeline import (build_pipeline_schedule,
+                                             generate_split_points,
+                                             stage_ids_this_rank)
 from torchtitan.tools.logging import logger
-
-from flame.models.parallelize_fla import (
-    get_blocks,
-    get_real_components_name,
-    get_actual_model,
-)
 
 DeviceType = Union[int, str, torch.device]
 

--- a/train.py
+++ b/train.py
@@ -17,12 +17,15 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 import fla  # noqa
 from fla.modules.fused_linear_cross_entropy import FusedLinearCrossEntropyLoss
 from fla.ops.common.utils import prepare_position_ids
+
+
 from flame.components.checkpoint import TrainState
 from flame.components.optimizer import build_lr_schedulers
 from flame.config_manager import JobConfig
 from flame.data import build_dataloader, shuffle
 from flame.models.parallelize_fla import parallelize_fla
 from flame.models.pipeline_fla import pipeline_fla
+from flame.models.activation_offloading import get_act_offloading_ctx_manager
 from flame.tools.utils import get_num_flop_per_token
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.ft import FTParallelDims, init_ft_manager
@@ -31,14 +34,22 @@ from torchtitan.components.optimizer import build_optimizers
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed import utils as dist_utils
 from torchtitan.protocols.model_converter import build_model_converters
-from torchtitan.protocols.train_spec import (TrainSpec, get_train_spec,
-                                             register_train_spec)
+from torchtitan.protocols.train_spec import (
+    TrainSpec,
+    get_train_spec,
+    register_train_spec,
+)
 from torchtitan.tools import utils
 from torchtitan.tools.logging import init_logger, logger
-from torchtitan.tools.metrics import (build_device_memory_monitor,
-                                      build_metric_logger)
-from torchtitan.tools.profiling import (maybe_enable_memory_snapshot,
-                                        maybe_enable_profiling)
+from torchtitan.tools.metrics import (
+    build_device_memory_monitor,
+    build_metric_logger,
+    ensure_pp_loss_visible,
+)
+from torchtitan.tools.profiling import (
+    maybe_enable_memory_snapshot,
+    maybe_enable_profiling,
+)
 
 register_train_spec(
     TrainSpec(
@@ -122,6 +133,16 @@ def main(job_config: JobConfig):
         dp_degree, dp_rank = 1, 0
 
     if parallel_dims.pp_enabled:
+        raise NotImplementedError(
+            "Pipeline parallelism is not supported in this version"
+        )
+        """
+        ! TODO[flame]: We need to fix the pipeline parallelism for flame
+        [x] Match the key of models' components with the actual naming
+        [ ] Fix the post-init and tie-embedding for pipeline parallelism, HF's transformer automatically
+            forces to tie if head is None, we need to handle this case
+        [ ] 
+        """
         pp_mesh = world_mesh["pp"]
 
     # Set random seed, and maybe enable deterministic mode (mainly for debugging, expect perf loss)
@@ -372,7 +393,10 @@ def main(job_config: JobConfig):
     )
     with torch.device("meta"):
         model = AutoModelForCausalLM.from_config(model_config)
-        if model_config.fuse_cross_entropy:
+        if (
+            getattr(model_config, "fuse_cross_entropy", False)
+            and FusedLinearCrossEntropyLoss is not None
+        ):
             model.criterion = FusedLinearCrossEntropyLoss(
                 num_chunks=8 // parallel_dims.tp
             )
@@ -402,6 +426,7 @@ def main(job_config: JobConfig):
 
     # apply parallelisms and initialization
     if parallel_dims.pp_enabled:
+
         # apply PT-D Pipeline Parallel
         (
             pp_schedule,
@@ -430,6 +455,10 @@ def main(job_config: JobConfig):
             with torch.no_grad():
                 m.post_init()
             m.train()
+
+        # confirm that user will be able to view loss metrics on the console
+        ensure_pp_loss_visible(parallel_dims, job_config, color)
+
     else:
         # apply PT-D Tensor Parallel, activation checkpointing, torch.compile, Data Parallel
         train_spec.parallelize_fn(model, world_mesh, parallel_dims, job_config)
@@ -502,6 +531,11 @@ def main(job_config: JobConfig):
         job_config.experimental.enable_compiled_autograd,
     )
 
+    activation_offload_context = get_act_offloading_ctx_manager(
+        model,
+        job_config.activation_offload.mode == "full",
+    )
+
     # variables used to keep info for metrics logging
     ntokens_since_last_log = 0
     data_loading_times = []
@@ -542,11 +576,14 @@ def main(job_config: JobConfig):
         f"{color.green}  Number of parameters = {model_param_count:,} {color.reset}"
     )
 
-    with maybe_enable_profiling(
-        job_config, global_step=train_state.step
-    ) as torch_profiler, maybe_enable_memory_snapshot(
-        job_config, global_step=train_state.step
-    ) as memory_profiler:
+    with (
+        maybe_enable_profiling(
+            job_config, global_step=train_state.step
+        ) as torch_profiler,
+        maybe_enable_memory_snapshot(
+            job_config, global_step=train_state.step
+        ) as memory_profiler,
+    ):
         while train_state.step < job_config.training.steps:
             train_state.step += 1
             gc_handler.run(train_state.step)
@@ -587,9 +624,11 @@ def main(job_config: JobConfig):
                 if cu_seqlens is not None:
                     position_ids = prepare_position_ids(cu_seqlens).to(torch.int32)
                 else:
-                    position_ids = torch.arange(
-                        0, input_ids.shape[1], device=device_type
-                    ).repeat(input_ids.shape[0], 1).to(torch.int32)
+                    position_ids = (
+                        torch.arange(0, input_ids.shape[1], device=device_type)
+                        .repeat(input_ids.shape[0], 1)
+                        .to(torch.int32)
+                    )
                 # apply context parallelism if cp is enabled
                 # ensure CP handles the separate freqs_cis buffer for each pp stage
                 optional_context_parallel_ctx = (
@@ -606,36 +645,44 @@ def main(job_config: JobConfig):
 
                 # #! TODO[flame], we should distribute the position_ids as well with CP
                 if parallel_dims.pp_enabled:
+                    raise NotImplementedError(
+                        "Pipeline parallelism is not supported in this version"
+                    )
                     # Pipeline Parallel forward / backward inside step() call
-                    is_last_stage = pp_mesh.get_local_rank() == pp_mesh.size() - 1
-
                     with train_context(optional_context_parallel_ctx):
-                        if pp_mesh.get_local_rank() == 0:
-                            pp_schedule.step(input_ids)
-                        elif is_last_stage:
-                            losses = []
-                            pp_schedule.step(target=labels, losses=losses)
+                        targets, losses = (
+                            (labels, []) if has_last_stage else (None, None)
+                        )
+
+                        if has_first_stage:
+                            pp_schedule.step(input_ids, target=targets, losses=losses)
                         else:
-                            pp_schedule.step()
+                            pp_schedule.step(target=targets, losses=losses)
 
                     # accumulate losses across pipeline microbatches
                     # TODO: PP+FSDP unexpectedly puts the loss back to the CPU
                     loss = (
                         torch.mean(torch.stack(losses)).to(device)
-                        if is_last_stage
+                        if has_last_stage
                         else torch.tensor([-1.0], device=device)
                     )
                 else:
                     # Non-PP forward / backward
-                    with train_context(optional_context_parallel_ctx):
+                    with train_context(
+                        optional_context_parallel_ctx, activation_offload_context
+                    ):
                         output = model(
                             input_ids=input_ids,
                             labels=labels,
                             position_ids=position_ids,
                             cu_seqlens=cu_seqlens,
                         )
-                        loss = output.loss / job_config.training.gradient_accumulation_steps
+                        loss = (
+                            output.loss
+                            / job_config.training.gradient_accumulation_steps
+                        )
                         loss.backward()
+
                 losses.append(loss)
             loss = sum(losses)
 

--- a/train.py
+++ b/train.py
@@ -17,15 +17,13 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 import fla  # noqa
 from fla.modules.fused_linear_cross_entropy import FusedLinearCrossEntropyLoss
 from fla.ops.common.utils import prepare_position_ids
-
-
 from flame.components.checkpoint import TrainState
 from flame.components.optimizer import build_lr_schedulers
 from flame.config_manager import JobConfig
 from flame.data import build_dataloader, shuffle
+from flame.models.activation_offloading import get_act_offloading_ctx_manager
 from flame.models.parallelize_fla import parallelize_fla
 from flame.models.pipeline_fla import pipeline_fla
-from flame.models.activation_offloading import get_act_offloading_ctx_manager
 from flame.tools.utils import get_num_flop_per_token
 from torchtitan.components.checkpoint import CheckpointManager
 from torchtitan.components.ft import FTParallelDims, init_ft_manager
@@ -34,22 +32,15 @@ from torchtitan.components.optimizer import build_optimizers
 from torchtitan.distributed import ParallelDims
 from torchtitan.distributed import utils as dist_utils
 from torchtitan.protocols.model_converter import build_model_converters
-from torchtitan.protocols.train_spec import (
-    TrainSpec,
-    get_train_spec,
-    register_train_spec,
-)
+from torchtitan.protocols.train_spec import (TrainSpec, get_train_spec,
+                                             register_train_spec)
 from torchtitan.tools import utils
 from torchtitan.tools.logging import init_logger, logger
-from torchtitan.tools.metrics import (
-    build_device_memory_monitor,
-    build_metric_logger,
-    ensure_pp_loss_visible,
-)
-from torchtitan.tools.profiling import (
-    maybe_enable_memory_snapshot,
-    maybe_enable_profiling,
-)
+from torchtitan.tools.metrics import (build_device_memory_monitor,
+                                      build_metric_logger,
+                                      ensure_pp_loss_visible)
+from torchtitan.tools.profiling import (maybe_enable_memory_snapshot,
+                                        maybe_enable_profiling)
 
 register_train_spec(
     TrainSpec(
@@ -141,7 +132,7 @@ def main(job_config: JobConfig):
         [x] Match the key of models' components with the actual naming
         [ ] Fix the post-init and tie-embedding for pipeline parallelism, HF's transformer automatically
             forces to tie if head is None, we need to handle this case
-        [ ] 
+        [ ]
         """
         pp_mesh = world_mesh["pp"]
 


### PR DESCRIPTION
1. fix some bugs, 
2. fix parts of PP-related code, but PP still does…not work yet, i turn-off the pp for now, 
3. add activation offload as experimental API. (this is not well-optimized, as we see below the pre-fetch is not overlapped)
```
# 7b, ctx=4096, BS=2, FSDP on 4xGH200
# W/o Offload memory: 87.87GiB tgs:   8,089
# W/  Offload memory: 34.48GiB tgs:   3,331
```
The code is from https://github.com/pytorch/torchtune/blob/main/torchtune/training/_activation_offloading.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to enable activation offloading, allowing users to choose between different offload modes for improved training memory efficiency.
  - Enabled dynamic management of activation tensors to optimize GPU memory usage during model training.

- **Refactor**
  - Enhanced pipeline and parallel processing logic for clearer control flow and improved error handling, ensuring that unsupported configurations are communicated effectively.
  - Improved readability and organization of the model manipulation logic, enhancing maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->