### PR TITLE
add back grad_norm metric

### DIFF
--- a/flame/train.py
+++ b/flame/train.py
@@ -733,7 +733,10 @@ def main(job_config: JobConfig):
                     train_state.step,
                     global_avg_loss,
                     global_max_loss,
-                    extra_metrics={"loss_metrics/grad_norm": grad_norm.item()},
+                    extra_metrics={
+                        "optimizer/grad_norm": grad_norm.item(),
+                        "optimizer/skipped_step": train_state.skipped_step,              
+                    },
                 )
 
             checkpoint.save(

--- a/flame/train.py
+++ b/flame/train.py
@@ -730,10 +730,6 @@ def main(job_config: JobConfig):
 
                 # Log using the metric processor
                 last_lr = lr_schedulers.schedulers[0].get_last_lr()[0]
-                # tokens per second per device, abbreviated as tgs
-                tgs = metric_logger.ntokens_since_last_log / (
-                    time_delta * parallel_dims.non_data_parallel_size
-                )
                 eta = (
                     train_state.elapsed
                     * (job_config.training.steps - train_state.step)
@@ -744,16 +740,14 @@ def main(job_config: JobConfig):
                     global_avg_loss,
                     global_max_loss,
                     extra_metrics={
+                        "optimizer/lr": last_lr,
                         "optimizer/grad_norm": grad_norm.item(),
                         "optimizer/skipped_step": train_state.skipped_step,
-                        "optimizer/lr": last_lr,
-                        "tgs": tgs,
                     },
                 )
 
                 logger.info(
                     f"{color.blue}lr: {last_lr:.4e} gnorm: {grad_norm:5.2f} "
-                    f"{color.red}tgs: {round(tgs):7,} "
                     f"{color.magenta}[{str(train_state.elapsed).split('.')[0]:>8}<{str(eta).split('.')[0]:>8}]{color.reset}"
                 )
 

--- a/flame/train.py
+++ b/flame/train.py
@@ -729,7 +729,12 @@ def main(job_config: JobConfig):
                 train_state.global_max_losses.append(global_max_loss)
 
                 # Log using the metric processor
-                metric_logger.log(train_state.step, global_avg_loss, global_max_loss)
+                metric_logger.log(
+                    train_state.step,
+                    global_avg_loss,
+                    global_max_loss,
+                    extra_metrics={"loss_metrics/grad_norm": grad_norm.item()},
+                )
 
             checkpoint.save(
                 train_state.step, force=(train_state.step == job_config.training.steps)


### PR DESCRIPTION
add back the grad_norm and skipped_step metric via the new log api in torchtitan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

This release delivers improvements to system stability and training process monitoring:

- **Chores**
  - Upgraded a core third-party dependency to the latest version to bolster overall performance and reliability.

- **New Features**
  - Enhanced training logging to capture additional diagnostic metrics, including gradient norms, last learning rate, and estimated time of arrival, providing more comprehensive insights during training sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->