### PR TITLE
Fix custom model registration by adding `custom_models/__init__.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,7 @@ To set up multi-node training:
    - Register your models with the `AutoModelForCausalLM`, `AutoModel` and `AutoConfig` classes (see `custom_models/sba/__init__.py` for an example)
 4. Create a config file for your custom model, just need to specify the `model_type` to the one you just named for your custom model (example: `configs/sba_340m.json`).
 5. Training is extremely simple, you can just use the `flame.train.py` script to train your custom model.
+6. Edit `custom_models/__init__.py` to import your custom model (e.g., `from . import sba`). Set `__all__` accordingly so only valid packages are exposed.
 
 
 

--- a/custom_models/__init__.py
+++ b/custom_models/__init__.py
@@ -1,0 +1,3 @@
+from . import sba
+
+__all__ = ["sba"]

--- a/train.sh
+++ b/train.sh
@@ -66,7 +66,7 @@ steps=$(grep -oP '(?<=--training.steps )[^ ]+' <<< "$params")
 config=$(grep -oP '(?<=--model.config )[^ ]+' <<< "$params")
 tokenizer=$(grep -oP '(?<=--model.tokenizer_path )[^ ]+' <<< "$params")
 model=$(
-  python -c "import fla, sys; from transformers import AutoConfig; print(AutoConfig.from_pretrained(sys.argv[1]).to_json_string())" "$config" | jq -r '.model_type'
+  python -c "import fla, sys, custom_models; from transformers import AutoConfig; print(AutoConfig.from_pretrained(sys.argv[1]).to_json_string())" "$config" | jq -r '.model_type'
 )
 
 mkdir -p $path


### PR DESCRIPTION
This PR adds `custom_models/__init__.py` to ensure proper model registration with `AutoConfig` and `AutoModelForCausalLM`
Also updates `train.sh` to explicitly import `custom_models` when parsing the model name (used in wandb run name)

related issue: #35 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the instructions for adding custom models, clarifying the need to import new models and configure their exposure in the initialization file.

* **New Features**
  * Introduced an initialization file for custom models, ensuring only specified models are publicly available.

* **Chores**
  * Adjusted the training script to import custom models, improving compatibility with custom configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->