### PR TITLE
Remove no op model compile

### DIFF
--- a/flame/models/parallelize_fla.py
+++ b/flame/models/parallelize_fla.py
@@ -399,9 +399,6 @@ def apply_compile(model: nn.Module):
         lm_head = torch.compile(getattr(model, lm_head_key), fullgraph=True)
         model.register_module(lm_head_key, lm_head)
 
-    logger.info("Compiling the entire model with torch.compile")
-    model = torch.compile(model)
-
 
 def apply_fsdp(
     model: nn.Module,


### PR DESCRIPTION
In `flame/models/parallelize_fla` you apply model compilation using `apply_compile`, which does the following:

```python
def apply_compile(model: nn.Module):
    """
    Apply torch.compile to each block, which makes compilation efficient due to
    repeated structure. Alternatively one can compile the whole model (after applying DP).
    """
    ....
    logger.info("Compiling the entire model with torch.compile")
    model = torch.compile(model)
 
 ...
 
     if job_config.training.compile:
        apply_compile(model)
```

while this does compile some individual modules within the model, the model itself won't be compiled, since `torch.compile` isn't an in-place operation. Maybe I am missing something here, but the last two lines of `apply_compile` are meaningless without returning the wrapped model and replacing the old one. If we compile each block of the model anyway this is redundant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized model compilation process by streamlining the compilation workflow while maintaining per-block compilation functionality, resulting in improved processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->