### PR TITLE
Fix `convert_hf_to_dcp`

### DIFF
--- a/flame/utils/convert_hf_to_dcp.py
+++ b/flame/utils/convert_hf_to_dcp.py
@@ -21,7 +21,7 @@ def convert_hf_weights(model: str, checkpoint: str):
     logger.info(f"Writing to DCP at '{checkpoint}'")
     checkpoint.mkdir(parents=True, exist_ok=True)
     storage_writer = DCP.filesystem.FileSystemWriter(checkpoint, thread_count=8)
-    DCP.save({"model": state_dict}, storage_writer=storage_writer)
+    DCP.save(state_dict, storage_writer=storage_writer)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

- `convert_hf_to_dcp` previously saved weights under a nested `{"model": state_dict}` key, producing `model.model.*` entries.
- `flame/torchtitan` expects a flat `model.*` state dict for seed checkpoints; the nested layout broke `dcp.load` when resuming training.
- Updated the converter to save the flat state dict directly (`model.*` keys), matching the loader’s expectations.

### Testing

- Converted Qwen3-1.7B from Hugging Face using `python -m flame.utils.convert_hf_to_dcp --model Qwen/Qwen3-1.7B --checkpoint <path>/checkpoint/step-0` and verified keys are `model.*` (no `model.model.*`).
- Ran `train.sh` for continual training with that checkpoint; training now proceeds past checkpoint load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated the model weight storage format when converting from HuggingFace models. The saved checkpoint structure has been simplified, which may affect dependent workflows that rely on the previous model structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->