### PR TITLE
Initialize weights before parallelization

### DIFF
--- a/configs/rwkv7_380M.json
+++ b/configs/rwkv7_380M.json
@@ -1,0 +1,20 @@
+{
+    "model_type": "rwkv7",
+    "hidden_size": 1024,
+    "num_hidden_layers": 24,
+    "head_dim": 64,
+    "hidden_ratio": 4,
+    "hidden_act": "sqrelu",
+    "vocab_size": 32000,
+    "decay_low_rank_dim": 64,
+    "gate_low_rank_dim": 128,
+    "a_low_rank_dim": 64,
+    "v_low_rank_dim": 16,
+    "tie_word_embeddings": false,
+    "fuse_cross_entropy": true,
+    "fuse_norm": true,
+    "use_l2warp": false,
+    "attn_mode": "chunk",
+    "bos_token_id": 1,
+    "eos_token_id": 2
+}

--- a/flame/train.py
+++ b/flame/train.py
@@ -264,10 +264,14 @@ def main(job_config: JobConfig):
         # We need to iterate through model_parts to apply SPMD parallelisms, compilation,
         # optimizer, and checkpointing
         for m in model_parts:
-            # Initialize weights before parallelization so that models with
-            # custom .data= init (e.g. RWKV-7) operate on plain tensors
-            # instead of DTensors.  The temporary full-size allocation is
-            # freed once FSDP shards the parameters.
+            # Materialize and initialize weights before applying parallelisms.
+            # Some models (e.g. RWKV-7) compute position-dependent init values
+            # as regular tensors and assign via .data, which is incompatible
+            # with DTensors created by FSDP. Cost: full model in fp32
+            # temporarily on each rank (~4 bytes/param). This fits comfortably
+            # for models up to ~10B on 40GB GPUs or ~20B on 80GB GPUs. For
+            # larger models, set init_device="cpu" (e.g. via
+            # --training.enable_cpu_offload).
             m.to_empty(device=init_device)
             with torch.no_grad():
                 m.post_init()
@@ -278,7 +282,8 @@ def main(job_config: JobConfig):
         # confirm that user will be able to view loss metrics on the console
         ensure_pp_loss_visible(parallel_dims, job_config, color)
     else:
-        # Initialize weights before parallelization (see PP path above).
+        # Materialize and initialize weights before parallelization
+        # (see PP path comment above for rationale and memory thresholds).
         model.to_empty(device=init_device)
         with torch.no_grad():
             model.post_init()

--- a/flame/train.py
+++ b/flame/train.py
@@ -264,21 +264,26 @@ def main(job_config: JobConfig):
         # We need to iterate through model_parts to apply SPMD parallelisms, compilation,
         # optimizer, and checkpointing
         for m in model_parts:
-            # apply SPMD-style PT-D techniques
-            train_spec.parallelize_fn(m, world_mesh, parallel_dims, job_config)
+            # Initialize weights before parallelization so that models with
+            # custom .data= init (e.g. RWKV-7) operate on plain tensors
+            # instead of DTensors.  The temporary full-size allocation is
+            # freed once FSDP shards the parameters.
             m.to_empty(device=init_device)
             with torch.no_grad():
                 m.post_init()
+            # apply SPMD-style PT-D techniques
+            train_spec.parallelize_fn(m, world_mesh, parallel_dims, job_config)
             m.train()
 
         # confirm that user will be able to view loss metrics on the console
         ensure_pp_loss_visible(parallel_dims, job_config, color)
     else:
-        # apply PT-D Tensor Parallel, activation checkpointing, torch.compile, Data Parallel
-        train_spec.parallelize_fn(model, world_mesh, parallel_dims, job_config)
+        # Initialize weights before parallelization (see PP path above).
         model.to_empty(device=init_device)
         with torch.no_grad():
             model.post_init()
+        # apply PT-D Tensor Parallel, activation checkpointing, torch.compile, Data Parallel
+        train_spec.parallelize_fn(model, world_mesh, parallel_dims, job_config)
         model.train()
 
         model_parts = [model]


### PR DESCRIPTION
Models with custom position-dependent initialization (e.g. RWKV-7) assign values via `.data=`, which is incompatible with DTensors created by FSDP:

```
RuntimeError: aten.copy_.default: got mixed torch.Tensor and DTensor,
need to convert all torch.Tensor to DTensor before calling distributed operators!
```

Moves `to_empty()` and `post_init()` before `parallelize_fn()` so that weight initialization operates on plain tensors. The temporary full-model allocation is freed once FSDP shards the parameters.

Also adds an RWKV-7 380M config.

Verified with RWKV-7 380M on 15B tokens (8×A100-40GB, FSDP): [wandb](https://api.wandb.ai/links/puigde-epfl-epfl/qtp7zok7) | [model](https://huggingface.co/puigde/rwkv7-380M-15B-slimpajama)

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved training initialization to reduce temporary memory allocations and enhance stability for parallelized and non-parallelized training paths.

* **New Features**
  * Added a new rwkv7 380M model configuration, including model dimensions, tokenizer IDs, attention mode, and runtime options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->